### PR TITLE
API support

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,49 @@
+HTTP End-Points
+---------------
+
+The following HTTP end-points are implemented by the server:
+
+* `GET /`
+  * Show all known-nodes and their current status.
+* `GET /node/${fqdn}`
+   * Shows the last N (max 50) runs of puppet against the given node.
+   * This includes a graph of run-time.
+* `GET /radiator`
+   * This shows a simple dashboard/radiator view.
+* `GET /report/${n}`
+   * This shows useful output of a given run.
+* `POST /upload`
+   * Store a report, this is expected to be invoked solely by the puppet-master.
+
+In addition to that there is a simple end-point which is designed to
+return a list of all the nodes in the given state:
+
+* `GET /api/state/$state`
+
+
+API End-Points
+--------------
+
+Almost all of the existing end-points can be used for automation, and scripting
+as an API-end-point.  By default the various handlers return HTML-responses, as you would expect, but they can each be configured to return:
+
+* JSON
+* XML
+
+To receive a non-HTML response you merely need to set the HTTP `Accept` header appropriately.   To view your list of nodes you might try this, for example:
+
+    $ curl -H Accept:application/json http://localhost:3001/
+    $ curl -H Accept:application/xml  http://localhost:3001/
+
+Similarly the raditor-view can be shown:
+
+    $ curl -H Accept:application/xml  localhost:3001/radiator/
+    <PuppetState>
+     <State>changed</State>
+     <Count>0</Count>
+     <Percentage>0</Percentage>
+    </PuppetState>
+    <PuppetState>
+     <State>failed</State>
+     <Count>0</Count>
+     ..

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,31 +19,6 @@ binary to make your changes:
     go build .
 
 
-## End-Points
-
-There are several main end-points:
-
-* `GET /`
-  * Show all known-nodes and their current status.
-* `GET /node/${fqdn}`
-   * Shows the last N (max 50) runs of puppet against the given node.
-   * This includes a graph of run-time.
-* `GET /radiator`
-   * This shows a simple dashboard/radiator view.
-* `GET /report/${n}`
-   * This shows useful output of a given run.
-* `POST /upload`
-   * Store a report, this is expected to be invoked from the puppet-master.
-
-In addition to that there is a simple end-point which is designed to
-return a list of all the nodes in the given state:
-
-* `GET /api/state/$state`
-
-Only valid states are permitted (`changed`, `failed`, & `unchanged`).
-
-
-
 ## Code Quality
 
 Test our the test-suite coverage :

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This project is directly inspired by the [puppet-dashboard](https://github.com/s
    * This project only involves deploying a single binary.
 * It allows you to submit metrics to a carbon-receiver.
    * The metrics include a distinct count of each state, allowing you to raise alerts when nodes in the failed state are present.
+* The output can be used for scripting, and automation.
+   * All output is available as [JSON/XML](API.md) in addition to human-viewable HTML.
 
 There are [screenshots included within this repository](screenshots/), and you can view a [sample installation here](https://master.steve.org.uk/).
 

--- a/cmd_serve.go
+++ b/cmd_serve.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"flag"
 	"fmt"
@@ -154,11 +155,38 @@ func RadiatorView(res http.ResponseWriter, req *http.Request) {
 	}
 
 	//
-	// Populate & return the template.
+	// What kind of reply should we send?
 	//
-	src := string(tmpl)
-	t := template.Must(template.New("tmpl").Parse(src))
-	t.Execute(res, data)
+	accept := req.Header.Get("Accept")
+
+	switch accept {
+	case "application/json":
+		js, err := json.Marshal(data)
+
+		if err != nil {
+			status = http.StatusInternalServerError
+			return
+		}
+		res.Header().Set("Content-Type", "application/json")
+		res.Write(js)
+
+	case "application/xml":
+		x, err := xml.MarshalIndent(data, "", "  ")
+		if err != nil {
+			status = http.StatusInternalServerError
+			return
+		}
+
+		res.Header().Set("Content-Type", "application/xml")
+		res.Write(x)
+	default:
+		//
+		// Populate & return the template.
+		//
+		src := string(tmpl)
+		t := template.Must(template.New("tmpl").Parse(src))
+		t.Execute(res, data)
+	}
 }
 
 //
@@ -327,11 +355,38 @@ func ReportHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	//
-	// All done.
+	// What kind of reply should we send?
 	//
-	src := string(tmpl)
-	t := template.Must(template.New("tmpl").Parse(src))
-	t.Execute(res, report)
+	accept := req.Header.Get("Accept")
+
+	switch accept {
+	case "application/json":
+		js, err := json.Marshal(report)
+
+		if err != nil {
+			status = http.StatusInternalServerError
+			return
+		}
+		res.Header().Set("Content-Type", "application/json")
+		res.Write(js)
+
+	case "application/xml":
+		x, err := xml.MarshalIndent(report, "", "  ")
+		if err != nil {
+			status = http.StatusInternalServerError
+			return
+		}
+
+		res.Header().Set("Content-Type", "application/xml")
+		res.Write(x)
+	default:
+		//
+		// Populate & return the template.
+		//
+		src := string(tmpl)
+		t := template.Must(template.New("tmpl").Parse(src))
+		t.Execute(res, report)
+	}
 }
 
 //
@@ -407,11 +462,38 @@ func NodeHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	//
-	//  Populate the template and return it.
+	// What kind of reply should we send?
 	//
-	src := string(tmpl)
-	t := template.Must(template.New("tmpl").Parse(src))
-	t.Execute(res, x)
+	accept := req.Header.Get("Accept")
+
+	switch accept {
+	case "application/json":
+		js, err := json.Marshal(reports)
+
+		if err != nil {
+			status = http.StatusInternalServerError
+			return
+		}
+		res.Header().Set("Content-Type", "application/json")
+		res.Write(js)
+
+	case "application/xml":
+		x, err := xml.MarshalIndent(reports, "", "  ")
+		if err != nil {
+			status = http.StatusInternalServerError
+			return
+		}
+
+		res.Header().Set("Content-Type", "application/xml")
+		res.Write(x)
+	default:
+		//
+		//  Populate the template and return it.
+		//
+		src := string(tmpl)
+		t := template.Must(template.New("tmpl").Parse(src))
+		t.Execute(res, x)
+	}
 }
 
 //
@@ -479,11 +561,38 @@ func IndexHandler(res http.ResponseWriter, req *http.Request) {
 	x.Nodes = NodeList
 
 	//
-	//  Populate the template and return it.
+	// What kind of reply should we send?
 	//
-	src := string(tmpl)
-	t := template.Must(template.New("tmpl").Parse(src))
-	t.Execute(res, x)
+	accept := req.Header.Get("Accept")
+
+	switch accept {
+	case "application/json":
+		js, err := json.Marshal(NodeList)
+
+		if err != nil {
+			status = http.StatusInternalServerError
+			return
+		}
+		res.Header().Set("Content-Type", "application/json")
+		res.Write(js)
+
+	case "application/xml":
+		x, err := xml.MarshalIndent(NodeList, "", "  ")
+		if err != nil {
+			status = http.StatusInternalServerError
+			return
+		}
+
+		res.Header().Set("Content-Type", "application/xml")
+		res.Write(x)
+	default:
+		//
+		//  Populate the template and return it.
+		//
+		src := string(tmpl)
+		t := template.Must(template.New("tmpl").Parse(src))
+		t.Execute(res, x)
+	}
 }
 
 //


### PR DESCRIPTION
Each of the main handlers now will return either:
    
* HTML
   * The default
* JSON
   * When the HTTP-Accept header is `application/json`.
* XML
   * When the HTTP-Accept header is `application/xml`.

This is documented in `API.md` which is linked to from `README.md`, which should make it discoverable, and all together this closes #27.
