### PR TITLE
Add debian instructions for XCC

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -37,13 +37,18 @@ tool:
 
 # Cross compiling puppet-summary
 
-In this example, the compilation is happening on x86_64 Fedora system with a target of Raspbian on ARM (raspberry PI). This should be quite similar (different package names basically, for Debian-based distros).
+In this example, the compilation is happening on x86_64 Fedora or a Debian 9 amd64 system with a target of Raspbian on ARM (raspberry PI).
 
 ## Install the packages you need.
 
+### Fedora
 `# dnf install binutils-arm-linux-gnu cross-gcc-common cross-binutils-common gcc-c++-arm-linux-gnu kernel-cross-headers glibc-arm-linux-gnu  glibc-arm-linux-gnu-devel`
 
+### Debian
+` # apt-get install  cpp-6-arm-linux-gnueabihf g++-6-arm-linux-gnueabihf gcc-6-arm-linux-gnueabihf gcc-6-arm-linux-gnueabihf-base gccgo-6-arm-linux-gnueabihf
 ## Manually fix pthreads
+
+_Note:_ This is only required on Fedora builders.
 
 The way cgo works for cross compiles, it assumes a sysroot, which is normal. However, the way pthreads is called in the github.com/mattn/go-sqlite3 package, it requires and absolute path, but that path is relative to the sysroot provided.
 
@@ -53,7 +58,11 @@ The way cgo works for cross compiles, it assumes a sysroot, which is normal. How
 
 I use `-v` when cross compiling because it will give much more info if something errors out.
 
+### Fedora
 `$ CC=arm-linux-gnu-gcc CGO_ENABLED=1 GOOS=linux GOARCH=arm CGO_LDFLAGS=--sysroot=/usr/arm-linux-gnu CGO_CFLAGS=--sysroot=/usr/arm-linux-gnu go build -v .`
+
+### Debian
+`$ CC=arm-linux-gnueabihf-gcc-6  CGO_ENABLED=1 GOOS=linux GOARCH=arm CGO_LDFLAGS=--sysroot=/usr/arm-linux-gnu CGO_CFLAGS=--sysroot=/usr/arm-linux-gnu go build -v .`
 
 ## Verify build
 


### PR DESCRIPTION
I was able to reproduce the cross compile from a debian 9 amd64 system.
Instructions are updated for that as well.