### PR TITLE
Enclose logs inside `pre` tags and compact output

### DIFF
--- a/data/report.template
+++ b/data/report.template
@@ -64,7 +64,7 @@
           </div>
           <div class="col-sm-11 col-md-11">
             {{range .LogMessages}}
-            <p>{{.}}</p>
+            <pre style="padding: 5px 9px;"><p style="margin: 0;">{{.}}</p></pre>
             {{else}}
             <p>Nothing reported.</p>
             {{end}}


### PR DESCRIPTION
As talked in #40, this is a PR for changing two things:
- enclose log messages inside `pre` tags
- compact the size of pre tag, so we don't waste space