### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# First build puppet-summary
+FROM alpine
+RUN apk --no-cache add go git musl-dev
+RUN go get -u github.com/skx/puppet-summary
+
+# Now put it in a container without all the build tools
+FROM alpine
+WORKDIR /root/
+COPY --from=0 /root/go/bin/puppet-summary .
+ENV PORT=3001
+EXPOSE 3001
+VOLUME /app
+ENTRYPOINT ["/root/puppet-summary", "serve", "-host","0.0.0.0", "-db-file", "/app/db1.sqlite" ]

--- a/HACKING.md
+++ b/HACKING.md
@@ -36,6 +36,20 @@ To view the coverage report in HTML, via your browser this is good:
      go tool cover -html=cover.out -o foo.html
      firefox foo.html
 
+# Running a container
+
+This project now ships a Dockerfile. The goal is to build a small image with
+puppet-summary installed on it. This uses multi-stage builds for docker and
+thus requires docker version 17.05 or higher. The container is based on alpine
+linux and should be around 20MB. 
+
+To build:
+
+    docker build -t puppet-summary:<current version> .
+  
+To run:
+   
+    docker run -d -v app:/app -p 3001:3001 puppet-summary
 
 
 # Cross compiling puppet-summary


### PR DESCRIPTION
This commit adds a Dockerfile for building/running puppet-summary via a container. See HACKING.md for basic instructions.

Fixes #43