### PR TITLE
adding more detail to logs

### DIFF
--- a/yaml_parser.go
+++ b/yaml_parser.go
@@ -299,7 +299,7 @@ func parseLogs(y *simpleyaml.Yaml, out *PuppetReport) error {
 		}
 
 		if len(m["message"]) > 0 {
-			logged = append(logged, m["message"])
+			logged = append(logged, m["source"] + " : " + m["message"])
 		}
 	}
 


### PR DESCRIPTION
Add more detail to the logs on the report page. Previously it would list 'Success' but not what was successful.

Old log:
`Tidying 0 files`

New log:
`/Stage[main]/Profiles::Puppetconf/Tidy[/opt/puppetlabs/puppet/cache/reports] : Tidying 0 files`