### PR TITLE
timeout params

### DIFF
--- a/cmd_serve.go
+++ b/cmd_serve.go
@@ -1042,8 +1042,8 @@ func serve(settings serveCmd) {
 	srv := &http.Server{
 		Addr:         bind,
 		Handler:      loggedRouter,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  time.Duration(settings.readTimeout) * time.Second,
+		WriteTimeout: time.Duration(settings.writeTimeout) * time.Second,
 	}
 
 	//
@@ -1059,11 +1059,13 @@ func serve(settings serveCmd) {
 // The options set by our command-line flags.
 //
 type serveCmd struct {
-	autoPrune bool
-	bindHost  string
-	bindPort  int
-	dbFile    string
-	prefix    string
+	autoPrune    bool
+	bindHost     string
+	bindPort     int
+	readTimeout  int
+	writeTimeout int
+	dbFile       string
+	prefix       string
 }
 
 //
@@ -1082,6 +1084,8 @@ func (*serveCmd) Usage() string {
 //
 func (p *serveCmd) SetFlags(f *flag.FlagSet) {
 	f.IntVar(&p.bindPort, "port", 3001, "The port to bind upon.")
+	f.IntVar(&p.readTimeout, "read-timeout", 5, "Timeout from when the connection is accepted to when the request body is fully read")
+	f.IntVar(&p.writeTimeout, "write-timeout", 10, "Timeout from the end of the request header read to the end of the response write")
 	f.BoolVar(&p.autoPrune, "auto-prune", false, "Prune reports automatically, once per week.")
 	f.StringVar(&p.bindHost, "host", "127.0.0.1", "The IP to listen upon.")
 	f.StringVar(&p.dbFile, "db-file", "ps.db", "The SQLite database to use.")

--- a/yaml_parser.go
+++ b/yaml_parser.go
@@ -299,7 +299,7 @@ func parseLogs(y *simpleyaml.Yaml, out *PuppetReport) error {
 		}
 
 		if len(m["message"]) > 0 {
-			logged = append(logged, m["message"])
+			logged = append(logged, m["source"] + " : " + m["message"])
 		}
 	}
 


### PR DESCRIPTION
Parameterize the http read and write timeouts with the defaults set to the current hard coded values

`puppet-summary serve -read-timeout 5 -write-timeout 10`