### PR TITLE
Set journal mode to WAL in SetupDB() DSN string

### DIFF
--- a/db.go
+++ b/db.go
@@ -84,7 +84,7 @@ func SetupDB(path string) error {
 	//
 	// Return if the database already exists.
 	//
-	db, err = sql.Open("sqlite3", path)
+	db, err = sql.Open("sqlite3", "file:"+path+"?_journal_mode=WAL")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Explicitly set WAL journaling mode in sql.Open() connection string,
to fix a bug where manual pruning fails (database locked) when a
puppet-summary process is already running.

Since "_journal_mode" was added as an option to the go-sqlite3 DSN,
DELETE seems to be used by default even if "_journal_mode" is set
by a pragma with db.Exec().