### PR TITLE
Don't cap node-reports to 50.

### DIFF
--- a/db.go
+++ b/db.go
@@ -592,7 +592,7 @@ func getReports(fqdn string) ([]PuppetReportSummary, error) {
 	//
 	// Select the status.
 	//
-	stmt, err := db.Prepare("SELECT id, fqdn, environment, state, executed_at, runtime, failed, changed, total, yaml_file FROM reports WHERE fqdn=? ORDER by executed_at DESC LIMIT 50")
+	stmt, err := db.Prepare("SELECT id, fqdn, environment, state, executed_at, runtime, failed, changed, total, yaml_file FROM reports WHERE fqdn=? ORDER by executed_at DESC")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This closes #74, by removing the hardwired limit of node-reports
we display.

While it might be more flexible to allow a configurable limit
too many flags get annoying so I think we'll just remove it.

If there are too many reports for a user/node then I'd suggest
pruning more frequently.